### PR TITLE
Add dark mode feature

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,13 @@
     <div class="container">
         <header>
             <h1>SEO Tag Visual Inspector</h1>
+            <div class="theme-switch-wrapper">
+                <label class="theme-switch" for="theme-toggle">
+                    <input type="checkbox" id="theme-toggle" />
+                    <span class="slider round"></span>
+                </label>
+                <span class="theme-switch-label">Dark Mode</span>
+            </div>
         </header>
         
         <div class="search-container">

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -199,4 +199,36 @@ document.addEventListener('DOMContentLoaded', () => {
             analyzeBtn.click();
         }
     });
+
+    // Theme Switcher Logic
+    const themeToggle = document.getElementById('theme-toggle');
+    const bodyElement = document.body;
+    const localStorageKey = 'darkModeEnabled';
+
+    // Function to apply theme based on preference
+    const applyTheme = (isDarkMode) => {
+        if (isDarkMode) {
+            bodyElement.classList.add('dark-mode');
+            if (themeToggle) themeToggle.checked = true;
+        } else {
+            bodyElement.classList.remove('dark-mode');
+            if (themeToggle) themeToggle.checked = false;
+        }
+    };
+
+    // Load saved theme preference when the page loads
+    // Check if themeToggle exists to prevent errors if element is missing
+    if (themeToggle) {
+        const savedPreference = localStorage.getItem(localStorageKey);
+        // If savedPreference is null (first visit), default to light mode (false).
+        // Otherwise, parse the string 'true' or 'false' to a boolean.
+        applyTheme(savedPreference === 'true');
+
+        // Event listener for theme toggle
+        themeToggle.addEventListener('change', () => {
+            const isDarkMode = themeToggle.checked;
+            applyTheme(isDarkMode);
+            localStorage.setItem(localStorageKey, isDarkMode);
+        });
+    }
 });

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -9,6 +9,18 @@
     --grey-color: #6c757d;
     --border-radius: 8px;
     --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    --body-bg-color-light: #f4f7fc;
+    --text-color-light: var(--dark-color);
+    --card-bg-color-light: white;
+    --input-bg-color-light: white;
+    --input-border-color-light: #ddd;
+    --preview-bg-color-light: #f8f9fa;
+    --tag-item-bg-color-light: #f8f9fa;
+    --tag-content-bg-color-light: #f0f0f0;
+    --google-h3-color-light: #1a0dab;
+    --google-a-color-light: #006621;
+    --google-p-color-light: #545454;
+    --social-p-color-light: #545454;
     --transition: all 0.3s ease;
 }
 
@@ -21,8 +33,8 @@
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     line-height: 1.6;
-    color: var(--dark-color);
-    background-color: #f4f7fc;
+    color: var(--text-color-light);
+    background-color: var(--body-bg-color-light);
     padding: 20px;
 }
 
@@ -44,9 +56,79 @@ h1 {
 }
 
 h2 {
-    color: var(--dark-color);
+    color: var(--text-color-light);
     margin-bottom: 1rem;
     font-size: 1.5rem;
+}
+
+/* Theme Toggle Switch */
+.theme-switch-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center; /* Center it in the header */
+    margin-top: 0.5rem; /* Add some space below the h1 if needed */
+    margin-bottom: 1.5rem; /* Space before search container */
+}
+
+.theme-switch-label {
+    margin-left: 10px;
+    font-size: 1rem;
+    color: var(--text-color-light); 
+}
+
+.theme-switch {
+    position: relative;
+    display: inline-block;
+    width: 50px; /* Smaller toggle */
+    height: 28px; /* Smaller toggle */
+}
+
+.theme-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: var(--transition);
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 20px; /* Adjusted for smaller toggle */
+    width: 20px;  /* Adjusted for smaller toggle */
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    transition: var(--transition);
+}
+
+input:checked + .slider {
+    background-color: var(--primary-color);
+}
+
+input:focus + .slider {
+    box-shadow: 0 0 1px var(--primary-color);
+}
+
+input:checked + .slider:before {
+    transform: translateX(22px); /* Adjusted for smaller toggle */
+}
+
+.slider.round {
+    border-radius: 28px; /* Adjusted for smaller toggle */
+}
+
+.slider.round:before {
+    border-radius: 50%;
 }
 
 /* Search Container */
@@ -61,7 +143,9 @@ h2 {
 #url-input {
     flex: 1;
     padding: 12px 15px;
-    border: 1px solid #ddd;
+    border: 1px solid var(--input-border-color-light);
+    background-color: var(--input-bg-color-light);
+    color: var(--text-color-light);
     border-radius: var(--border-radius) 0 0 var(--border-radius);
     font-size: 1rem;
     outline: none;
@@ -133,7 +217,7 @@ h2 {
 
 /* Cards */
 .seo-analysis-card, .preview-card {
-    background-color: white;
+    background-color: var(--card-bg-color-light);
     border-radius: var(--border-radius);
     padding: 1.5rem;
     box-shadow: var(--shadow);
@@ -166,7 +250,7 @@ h2 {
 
 .score-label {
     font-size: 1.5rem;
-    color: var(--grey-color);
+    color: var(--grey-color); /* Will be updated by dark mode vars */
 }
 
 /* SEO Tag List */
@@ -181,7 +265,7 @@ h2 {
     align-items: flex-start;
     padding: 0.8rem;
     border-radius: var(--border-radius);
-    background-color: #f8f9fa;
+    background-color: var(--tag-item-bg-color-light);
 }
 
 .tag-status {
@@ -211,7 +295,7 @@ h2 {
 }
 
 .tag-message {
-    color: var(--grey-color);
+    color: var(--grey-color); /* Will be updated by dark mode vars */
     font-size: 0.9rem;
 }
 
@@ -219,21 +303,22 @@ h2 {
     margin-top: 0.5rem;
     font-size: 0.9rem;
     word-break: break-all;
-    background-color: #f0f0f0;
+    background-color: var(--tag-content-bg-color-light);
+    color: var(--text-color-light);
     padding: 0.5rem;
     border-radius: 4px;
 }
 
 /* Preview Cards */
 .google-preview, .social-preview {
-    border: 1px solid #e0e0e0;
+    border: 1px solid var(--input-border-color-light); /* Assuming same as input border for consistency */
     border-radius: var(--border-radius);
     padding: 1rem;
-    background-color: #f8f9fa;
+    background-color: var(--preview-bg-color-light);
 }
 
 .google-preview h3 {
-    color: #1a0dab;
+    color: var(--google-h3-color-light);
     font-size: 1.2rem;
     margin-bottom: 0.3rem;
     overflow: hidden;
@@ -244,7 +329,7 @@ h2 {
 }
 
 .google-preview a {
-    color: #006621;
+    color: var(--google-a-color-light);
     font-size: 0.9rem;
     text-decoration: none;
     display: block;
@@ -255,7 +340,7 @@ h2 {
 }
 
 .google-preview p {
-    color: #545454;
+    color: var(--google-p-color-light);
     font-size: 0.9rem;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -270,7 +355,7 @@ h2 {
 }
 
 .social-preview p {
-    color: #545454;
+    color: var(--social-p-color-light);
     font-size: 0.9rem;
     margin-bottom: 0.5rem;
 }
@@ -300,6 +385,115 @@ h2 {
 footer {
     text-align: center;
     margin-top: 2rem;
-    color: var(--grey-color);
+    color: var(--grey-color); /* Will be updated by dark mode vars */
     font-size: 0.9rem;
+}
+
+/* Dark Mode Styles */
+body.dark-mode {
+    --primary-color: #79a6ff; /* Lighter blue for dark mode */
+    /* --success-color remains good */
+    /* --warning-color remains good */
+    /* --danger-color remains good */
+    --light-color: #2c2f33; /* Dark grey, was light */
+    --dark-color: #e6e6e6;  /* Light grey, was dark */
+    --grey-color: #999999;  /* Lighter grey for readability */
+    
+    --body-bg-color-dark: #1e1e1e;
+    --text-color-dark: var(--dark-color); /* Uses the new light grey */
+    --card-bg-color-dark: #2b2b2b;
+    --input-bg-color-dark: #333333;
+    --input-border-color-dark: #555555;
+    --preview-bg-color-dark: #333333;
+    --tag-item-bg-color-dark: #3a3a3a;
+    --tag-content-bg-color-dark: #444444;
+    --google-h3-color-dark: #8ab4f8; /* Lighter blue for links */
+    --google-a-color-dark: #57ab5a; /* Lighter green for links */
+    --google-p-color-dark: var(--grey-color); /* Uses the new lighter grey */
+    --social-p-color-dark: var(--grey-color); /* Uses the new lighter grey */
+
+    /* Apply dark mode variables */
+    background-color: var(--body-bg-color-dark);
+    color: var(--text-color-dark);
+}
+
+body.dark-mode h1 {
+    color: var(--primary-color);
+}
+
+body.dark-mode h2 {
+    color: var(--text-color-dark);
+}
+
+body.dark-mode #url-input {
+    background-color: var(--input-bg-color-dark);
+    color: var(--text-color-dark);
+    border-color: var(--input-border-color-dark);
+}
+
+body.dark-mode #analyze-btn {
+    /* Primary color is already set, text is white, which is good for dark mode */
+}
+
+body.dark-mode .seo-analysis-card,
+body.dark-mode .preview-card {
+    background-color: var(--card-bg-color-dark);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3); /* Slightly adjusted shadow for dark bg */
+}
+
+body.dark-mode .score-label {
+    color: var(--grey-color); /* Uses the dark mode's lighter grey */
+}
+
+body.dark-mode .tag-item {
+    background-color: var(--tag-item-bg-color-dark);
+}
+
+body.dark-mode .tag-message {
+    color: var(--grey-color); /* Uses the dark mode's lighter grey */
+}
+
+body.dark-mode .tag-content {
+    background-color: var(--tag-content-bg-color-dark);
+    color: var(--text-color-dark);
+}
+
+body.dark-mode .google-preview,
+body.dark-mode .social-preview {
+    background-color: var(--preview-bg-color-dark);
+    border-color: var(--input-border-color-dark);
+}
+
+body.dark-mode .google-preview h3 {
+    color: var(--google-h3-color-dark);
+}
+
+body.dark-mode .google-preview a {
+    color: var(--google-a-color-dark);
+}
+
+body.dark-mode .google-preview p,
+body.dark-mode .social-preview p {
+    color: var(--google-p-color-dark);
+}
+
+body.dark-mode footer {
+    color: var(--grey-color); /* Uses the dark mode's lighter grey */
+}
+
+body.dark-mode .theme-switch-label {
+    color: var(--text-color-dark);
+}
+
+/* Ensure slider background is appropriate in dark mode if not checked */
+body.dark-mode .slider {
+    background-color: #555; /* Darker grey for unchecked slider in dark mode */
+}
+
+body.dark-mode input:checked + .slider {
+    background-color: var(--primary-color); /* This is already using the dark mode primary color */
+}
+
+body.dark-mode .slider:before {
+    background-color: #e0e0e0; /* Slightly off-white for the toggle knob in dark mode */
 }


### PR DESCRIPTION
This commit introduces a dark mode option for the frontend.

Changes include:
- CSS updates in `frontend/styles.css` to define dark mode color variables and apply them using a `body.dark-mode` class.
- HTML modification in `frontend/index.html` to add a theme toggle switch in the header.
- JavaScript additions in `frontend/script.js` to handle:
    - Toggling the `dark-mode` class on the body.
    - Saving your theme preference in local storage.
    - Applying the saved theme preference on page load.